### PR TITLE
Fix comments policy

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,8 @@
 class PostsController < ApplicationController
-
   def show
     @topic = Topic.find(params[:topic_id])
     @post = Post.find(params[:id])
-    @comments = @post.comments#.paginate(page: params[:page], per_page: 10)
-    #@comment = Comment.new
+    @comments = @post.comments.paginate(page: params[:page], per_page: 10)
   end
 
   def new
@@ -38,7 +36,7 @@ class PostsController < ApplicationController
     @topic = Topic.find(params[:topic_id])
     @post = Post.find(params[:id])
     authorize @post
-    
+
     if @post.update_attributes(post_params)
       flash[:notice] = "Post was updated."
       redirect_to [@topic, @post]
@@ -63,7 +61,7 @@ class PostsController < ApplicationController
     end
   end
 
-  private 
+  private
 
   def post_params
     params.require(:post).permit(:title, :body)

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,4 @@
-
-<% form_for [@post, @post.comments.build] do |f| %>
-<%# form_for(@post, url: post_comments_path(@post.id), method: :post) do |f| %>
+<%= form_for [@post, @post.comments.build] do |f| %>
   <div class="form-group">
     <h4>New Comment:</h4>
     <%= f.text_field :body, rows: 8, class: 'form-control', placeholder: "Enter comment" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -21,15 +21,11 @@
 <div class="row">
   <div class="col-md-8">
     <% if policy(@comments).create? %>
-  
     <%= render 'comments/form' %>
-
     <% end %>
   </div>
   <div class="col-md-8">
     <h2>Comments</h2>
-
-    <%# render partial: 'comments/comment', collection: @comments %>
-
+    <%= render partial: 'comments/comment', collection: @comments %>
   </div>
 </div>


### PR DESCRIPTION
This fixes the assignment.

It was… so simple. I found what was wrong just by looking at the code for 5s, after a good night. We simply overlooked this _little_ change:

``` rhtml
# from
<%= form_for … %>
# to
<% form_for %>
```

Without the `=` character, the form is not added to the output! ([more details about the ERB syntax](http://www.stuartellis.eu/articles/erb/)). We removed that character when we commented out the line (`<%# form_for … %>`), but forgot to add it back when we uncommented the line at the end of the session.

You can merge that Pull Request, it will update your refactoring-create-comments topic branch. You'll then be able to merge that topic branch in master, if you want to keep this authorization feature in your application.
